### PR TITLE
fixed bug that caused default responses to not load if custom directo…

### DIFF
--- a/lib/express-custom-response.js
+++ b/lib/express-custom-response.js
@@ -16,8 +16,20 @@ var defaultReponse = ['serverError', 'validation', 'forbidden', 'notFound', 'ok'
 
 
 module.exports = function(reponse_path){
+
+  //add default reponses
+  defaultReponse.forEach(function(reponseName){
+    
+    //if user didn't override default reponse
+    if(!express.response[reponseName]){
+      express.response[reponseName] = require(__dirname + '/default/' + reponseName + '.js');
+    }
+    
+  });
+
   //check if directory exists
   if(fs.existsSync(reponse_path)){
+    
     //get user reponses
     var userRes = fs.readdirSync(reponse_path);
 
@@ -27,14 +39,6 @@ module.exports = function(reponse_path){
       express.response[reponseName] = require(reponse_path + '/' + response);
     });
 
-    //add default reponses
-    defaultReponse.forEach(function(reponseName){
-      //if user didn't override default reponse
-      if(!express.response[reponseName]){
-        express.response[reponseName] = require(__dirname + '/default/' + reponseName + '.js');
-      }
-    })
-
-
   }
+
 }


### PR DESCRIPTION
…ry was missing

The default response loader was encapsulated within the if statement that checked for a custom user directory. That means that the default responses were only loaded if the user provided a custom directory. 

I moved the default response loader to the top of the function so that it would load even if the user didn't add custom responses.

Furthermore, this allows default responses to be overwritten by custom user responses. 
